### PR TITLE
Fix: Bug Cannot find 'kGADAdSizeBanner' in scope

### DIFF
--- a/ios/Classes/Banner/BannerAdView.swift
+++ b/ios/Classes/Banner/BannerAdView.swift
@@ -6,7 +6,7 @@ class BannerAdView: NSObject, FlutterPlatformView {
     var controller: BannerAdController
     private let messenger: FlutterBinaryMessenger
     var result: FlutterResult?
-    private var adSize: GADAdSize = kGADAdSizeBanner
+    private var adSize: GADAdSize = GADAdSizeFromCGSize(CGSize(width: 320, height: 100))
 
     private func getAdSize(width: Float) -> GADAdSize {
         return GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(CGFloat(width))


### PR DESCRIPTION
I found this bug happening in several other people, not just me. Examples of this: [#133](https://github.com/bdlukaa/native_admob_flutter/issues/133)

When I saw the error, i think that **kGADAdSizeBanner** couldn't longer be used as the default.
So I made a small change like the following:

In native_admob_flutter/ios/Classes/Banner/BannerAdView.swift line 9:
I Change from:
```dart
private var adSize: GADAdSize = kGADAdSizeBanner
```

to :
```dart
private var adSize: GADAdSize = GADAdSizeFromCGSize(CGSize(width: 320, height: 100))
```

This will make the default large banner if the size is not specified, as shown in line 38.
Well i hope @bdlukaa  will merge this PR.
